### PR TITLE
feat: add dark/light theme toggle (fixes #4)

### DIFF
--- a/src/app/components/ThemeProvider.tsx
+++ b/src/app/components/ThemeProvider.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export default function ThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const savedTheme = localStorage.getItem("theme") as Theme | null;
+    if (savedTheme) {
+      setTheme(savedTheme);
+    } else if (window.matchMedia("(prefers-color-scheme: light)").matches) {
+      setTheme("light");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (mounted) {
+      document.documentElement.setAttribute("data-theme", theme);
+      localStorage.setItem("theme", theme);
+    }
+  }, [theme, mounted]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
+  if (!mounted) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTheme } from "./ThemeProvider";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface transition-colors hover:bg-surface-light"
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      {theme === "dark" ? (
+        <svg
+          className="h-4 w-4 text-foreground"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="h-4 w-4 text-foreground"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
-:root {
+/* Dark theme (default) */
+:root,
+[data-theme="dark"] {
   --background: #030712;
   --foreground: #f3f4f6;
   --accent: #6366f1;
@@ -10,6 +12,19 @@
   --surface-light: #1f2937;
   --border: #1f2937;
   --muted: #9ca3af;
+}
+
+/* Light theme */
+[data-theme="light"] {
+  --background: #ffffff;
+  --foreground: #111827;
+  --accent: #6366f1;
+  --accent-light: #4f46e5;
+  --accent-dark: #4338ca;
+  --surface: #f9fafb;
+  --surface-light: #f3f4f6;
+  --border: #e5e7eb;
+  --muted: #6b7280;
 }
 
 @theme inline {
@@ -34,6 +49,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .gradient-text {
@@ -58,8 +74,16 @@ body {
   box-shadow: 0 20px 40px rgba(99, 102, 241, 0.1);
 }
 
+[data-theme="light"] .card-hover:hover {
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.15);
+}
+
 .glow {
   box-shadow: 0 0 60px rgba(99, 102, 241, 0.15);
+}
+
+[data-theme="light"] .glow {
+  box-shadow: 0 0 60px rgba(99, 102, 241, 0.1);
 }
 
 .news-number {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ThemeProvider from "./components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,11 +25,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import ThemeToggle from "./components/ThemeToggle";
 
 const newsStories = [
   {
@@ -180,12 +181,15 @@ export default function Home() {
               FAQ
             </a>
           </div>
-          <a
-            href="#pricing"
-            className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-dark"
-          >
-            Subscribe
-          </a>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <a
+              href="#pricing"
+              className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-dark"
+            >
+              Subscribe
+            </a>
+          </div>
         </div>
       </nav>
 


### PR DESCRIPTION
## Summary
- Added `ThemeProvider` component using React Context for theme state management
- Added `ThemeToggle` button (sun/moon icons) in the navigation bar
- Added light theme CSS variables alongside existing dark theme in `globals.css`
- Theme preference persists via `localStorage`
- Supports system preference detection via `prefers-color-scheme`
- Smooth transition animation when switching themes

## Files Changed
- `src/app/components/ThemeProvider.tsx` — New theme context provider
- `src/app/components/ThemeToggle.tsx` — New toggle button component
- `src/app/globals.css` — Added light theme CSS variables
- `src/app/layout.tsx` — Integrated ThemeProvider wrapper
- `src/app/page.tsx` — Added ThemeToggle to navigation bar

## Test Plan
- [ ] Verify dark mode displays correctly (default)
- [ ] Verify light mode displays correctly when toggled
- [ ] Verify theme persists after page refresh (localStorage)
- [ ] Verify system preference is detected on first visit
- [ ] Verify smooth transition between themes
- [ ] Verify toggle button icon changes (sun ↔ moon)

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)