### PR TITLE
Add mobile menu, scroll animations, and subscribe API

### DIFF
--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { email } = body;
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json(
+        { error: "Email is required" },
+        { status: 400 }
+      );
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { error: "Please enter a valid email address" },
+        { status: 400 }
+      );
+    }
+
+    console.log(`[Subscribe] New subscription: ${email}`);
+
+    return NextResponse.json(
+      { message: "Subscribed successfully" },
+      { status: 200 }
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,3 +92,24 @@ body {
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
+
+/* Scroll-triggered animations */
+.scroll-fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.scroll-fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Mobile menu */
+.mobile-menu-overlay {
+  transition: opacity 0.2s ease;
+}
+
+.mobile-menu-panel {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- **Mobile hamburger menu (#6):** Slide-out nav panel on mobile with overlay backdrop, close on link click / Escape / outside click, body scroll lock when open
- **Scroll-triggered animations (#8):** News cards fade in and slide up as they enter the viewport using IntersectionObserver, with 100ms staggered delays, triggers once per card
- **Email subscribe API (#9):** `POST /api/subscribe` route with email validation, plus CTA form wired up with loading/success/error UI states

## Test plan
- [ ] On mobile viewport: tap hamburger icon, verify slide-out menu appears with nav links + Subscribe button
- [ ] Tap a nav link in mobile menu — menu should close and page should scroll to section
- [ ] Press Escape or tap outside the menu panel — menu should close
- [ ] Scroll down to the news section — cards should fade in with staggered animation
- [ ] Scroll back up and down again — animation should NOT re-trigger
- [ ] Enter a valid email in the CTA form and submit — should show "Subscribed successfully"
- [ ] Submit with an invalid email — should show validation error
- [ ] Submit with empty field — HTML5 required validation should block submission
- [ ] Run `npm run build` — zero errors, `/api/subscribe` route appears in output

Closes #6, closes #8, closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)